### PR TITLE
Add 'tabulate' to the list of dependencies

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,9 +4,19 @@ channel_targets:
   - nsls2forge main
 cdt_name:
   - cos6
+c_compiler_version:    # [linux]
+  - 7                  # [linux]
+cxx_compiler_version:  # [linux]
+  - 7                  # [linux]
 numpy:
+  - 1.16
+  - 1.16
   - 1.16
 python:
   - 3.7
+  - 3.8
+  - 3.9
 python_impl:
+  - cpython
+  - cpython
   - cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -23,6 +23,7 @@ requirements:
   run:
     - python
     - mysql-connector-python
+    - tabulate
 
 test:
   imports:


### PR DESCRIPTION
It's available in the `defaults` channel: https://anaconda.org/anaconda/tabulate.

This was added to the conda-forge counterpart via https://github.com/conda-forge/ispyb-feedstock/pull/34/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR27.

Closes: #2.